### PR TITLE
:beers: Fix linking error in demos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,13 +90,22 @@ jobs:
       os: baremetal
     secrets: inherit
 
-  demo_check_lpc4074:
+  demo_check_stm32f103c8:
     uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
     with:
       compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
       compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-lpc40.git
-      platform_profile: v2/lpc4074
+      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
+      platform_profile: v1/stm32f103c8
+    secrets: inherit
+
+  demo_check_stm32f103re:
+    uses: libhal/ci/.github/workflows/demo_builder.yml@5.x.y
+    with:
+      compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
+      compiler_profile: v1/arm-gcc-12.3
+      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
+      platform_profile: v1/stm32f103re
     secrets: inherit
 
   demo_check_lpc4078:
@@ -104,6 +113,6 @@ jobs:
     with:
       compiler_profile_url: https://github.com/libhal/arm-gnu-toolchain.git
       compiler_profile: v1/arm-gcc-12.3
-      platform_profile_url: https://github.com/libhal/libhal-lpc40.git
-      platform_profile: v2/lpc4078
+      platform_profile_url: https://github.com/libhal/libhal-arm-mcu.git
+      platform_profile: v1/lpc4078
     secrets: inherit

--- a/demos/platforms/lpc4078.cpp
+++ b/demos/platforms/lpc4078.cpp
@@ -108,7 +108,7 @@ extern "C"
 std::array<std::uint8_t, 6000> buffer1;
 std::array<std::uint8_t, 6000> buffer2;
 
-void initialize_platform(resource_list p_map)
+void initialize_platform(resource_list& p_map)
 {
   // Change the input frequency to match the frequency of the crystal attached
   // to the external OSC pins.


### PR DESCRIPTION
The link errors are due to the lack of an
`initalize_platform(resource_map&)` function within the `lpc4078.cpp` file. What was there was `initalize_platform(resource_map)`. Notice the lack of a `&`. Yeah, since that function didn't show up in link resolution, I be the whole file got dropped. If it had just said:

```
undefined reference to `initialize_platform(resource_list&)'
```

I would have tracked down the error. That is one annoyance with LTO. You get bizarre linking errors due to how dependency resolve themselves.